### PR TITLE
Switch to using File input format for repository scans #33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- General improvements:
+  - Updated `ps-rule-assert` task to use `File` input format for repository scans. [#33](https://github.com/microsoft/ps-rule/issues/33)
+    - The `Input.PathIgnore` option can be configured to exclude files.
+    - Path specs included in `.gitignore` are also automatically excluded.
+- Engineering:
+  - Updated to PSRule v0.20.0. [#34](https://github.com/microsoft/ps-rule/issues/34)
+
 ## v0.2.0
 
 What's changed since v0.1.0:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=0.19.0
+ARG MODULE_VERSION=0.20.0
 
 FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.10
 SHELL ["pwsh", "-Command"]

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -139,6 +139,7 @@ foreach ($m in $moduleNames) {
 
 Write-Host '';
 Write-Host "[info] Using Action: $Env:GITHUB_ACTION";
+Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";
 Write-Host "[info] Using InputType: $InputType";
@@ -168,13 +169,10 @@ try {
 
     # repository
     if ($InputType -eq 'repository') {
-        $items = New-Object -TypeName System.Collections.ArrayList;
         WriteDebug 'Running ''Assert-PSRule'' with repository as input.';
-        $Null = $items.Add((Get-Item -Path $InputPath));
-        $Null = $items.AddRange((Get-ChildItem -Path $InputPath -File -Recurse));
         Write-Host '';
         Write-Host '---';
-        $items.ToArray() | Assert-PSRule -Option (New-PSRuleOption -TargetName 'FullName') @invokeParams;
+        Assert-PSRule @invokeParams -InputPath $InputPath -Format File;
     }
     # inputPath
     elseif ($InputType -eq 'inputPath') {

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^0.19.0
+  PSRule: ^0.20.0
 
 tasks:
   clear:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -3,3 +3,7 @@
 output:
   culture:
   - en-US
+
+input:
+  pathIgnore:
+  - '*.md'


### PR DESCRIPTION
## PR Summary

- General improvements:
  - Updated `ps-rule-assert` task to use `File` input format for repository scans. #33
    - The `Input.PathIgnore` option can be configured to exclude files.
    - Path specs included in `.gitignore` are also automatically excluded.
- Engineering:
  - Updated to PSRule v0.20.0. #34

Fixes #33 
Fixes #34 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
