### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v0.3.0
+
+What's changed since v0.2.0:
+
 - General improvements:
   - Updated `ps-rule-assert` task to use `File` input format for repository scans. [#33](https://github.com/microsoft/ps-rule/issues/33)
     - The `Input.PathIgnore` option can be configured to exclude files.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ To learn about PSRule and how to write your own rules see [Getting started](http
 
 ## Usage
 
+To get the latest stable release use:
+
+```yaml
+- name: Run PSRule analysis
+  uses: Microsoft/ps-rule@v0.3.0
+```
+
+To get the latest bits use:
+
 ```yaml
 - name: Run PSRule analysis
   uses: Microsoft/ps-rule@main


### PR DESCRIPTION
## PR Summary

What's changed since v0.2.0:

- General improvements:
  - Updated `ps-rule-assert` task to use `File` input format for repository scans. #33
    - The `Input.PathIgnore` option can be configured to exclude files.
    - Path specs included in `.gitignore` are also automatically excluded.
- Engineering:
  - Updated to PSRule v0.20.0. #34

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
