### PR TITLE
Bump PSRule dependency to v0.21.0 #41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Engineering:
+  - Updated to PSRule v0.21.0. [#41](https://github.com/microsoft/ps-rule/issues/41)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/CHANGELOG.md#v0210)
 - Bug fixes:
   - Updated README example rule to use `PSRule.Data.RepositoryInfo` type filter. [#37](https://github.com/microsoft/ps-rule/issues/37)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=0.20.0
+ARG MODULE_VERSION=0.21.0
 
 FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.10
 SHELL ["pwsh", "-Command"]

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^0.20.0
+  PSRule: ^0.21.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

- Updated to PSRule v0.21.0. #41

Fixes #41 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
