### PR TITLE
Bump PSRule v1 and PS v7.1 #52 #53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v0.5.0:
+
+- Engineering:
+  - Updated to PSRule v1.0.0. [#52](https://github.com/microsoft/ps-rule/issues/52)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100)
+  - Updated docker image to PowerShell version v7.1. [#53](https://github.com/microsoft/ps-rule/issues/53)
+
 ## v0.5.0
 
 What's changed since v0.4.0:
@@ -14,7 +21,7 @@ What's changed since v0.4.0:
   - Added support for markdown output format. [#47](https://github.com/microsoft/ps-rule/issues/47)
 - Engineering:
   - Updated to PSRule v0.22.0. [#45](https://github.com/microsoft/ps-rule/issues/45)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/CHANGELOG.md#v0220)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0220)
 
 ## v0.4.0
 
@@ -22,7 +29,7 @@ What's changed since v0.3.0:
 
 - Engineering:
   - Updated to PSRule v0.21.0. [#41](https://github.com/microsoft/ps-rule/issues/41)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/CHANGELOG.md#v0210)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0210)
 - Bug fixes:
   - Updated README example rule to use `PSRule.Data.RepositoryInfo` type filter. [#37](https://github.com/microsoft/ps-rule/issues/37)
 
@@ -37,7 +44,7 @@ What's changed since v0.2.0:
     - See [upgrade notes][upgrade-v0.3.0] for details on breaking change.
 - Engineering:
   - Updated to PSRule v0.20.0. [#34](https://github.com/microsoft/ps-rule/issues/34)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/CHANGELOG.md#v0200)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200)
 
 See [upgrade notes][upgrade-v0.3.0] for helpful information when upgrading from previous versions.
 
@@ -49,7 +56,7 @@ What's changed since v0.1.0:
 
 - Engineering:
   - Updated to PSRule v0.19.0. [#27](https://github.com/microsoft/ps-rule/issues/27)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/CHANGELOG.md#v0190)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0190)
 
 ## v0.1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=0.22.0
+ARG MODULE_VERSION=1.0.0
 
-FROM mcr.microsoft.com/powershell:7.0.3-alpine-3.10
+FROM mcr.microsoft.com/powershell:7.1.0-alpine-3.10
 SHELL ["pwsh", "-Command"]
 RUN $ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; \
     $Null = New-Item -Path /ps_modules/ -ItemType Directory -Force; \

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^0.22.0
+  PSRule: ^1.0.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

- Updated to PSRule v1.0.0. #52
- Updated docker image to PowerShell version v7.1. #53

Fixes #52 
Fixes #53

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/CHANGELOG.md) has been updated with change under unreleased section
