### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,60 +4,10 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 [upgrade-notes]: docs/upgrade-notes.md
 
-## Unreleased
+## Current release
 
-What's changed since v0.5.0:
+- [v1](docs/CHANGELOG-v1.md)
 
-- Engineering:
-  - Updated to PSRule v1.0.0. [#52](https://github.com/microsoft/ps-rule/issues/52)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100)
-  - Updated docker image to PowerShell version v7.1. [#53](https://github.com/microsoft/ps-rule/issues/53)
+## Prior releases
 
-## v0.5.0
-
-What's changed since v0.4.0:
-
-- General improvements:
-  - Added support for markdown output format. [#47](https://github.com/microsoft/ps-rule/issues/47)
-- Engineering:
-  - Updated to PSRule v0.22.0. [#45](https://github.com/microsoft/ps-rule/issues/45)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0220)
-
-## v0.4.0
-
-What's changed since v0.3.0:
-
-- Engineering:
-  - Updated to PSRule v0.21.0. [#41](https://github.com/microsoft/ps-rule/issues/41)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0210)
-- Bug fixes:
-  - Updated README example rule to use `PSRule.Data.RepositoryInfo` type filter. [#37](https://github.com/microsoft/ps-rule/issues/37)
-
-## v0.3.0
-
-What's changed since v0.2.0:
-
-- General improvements:
-  - **Breaking change**: Updated `ps-rule` action to use `File` input format for repository analysis. [#33](https://github.com/microsoft/ps-rule/issues/33)
-    - The `Input.PathIgnore` option can be configured to exclude files.
-    - Path specs included in `.gitignore` are also automatically excluded.
-    - See [upgrade notes][upgrade-v0.3.0] for details on breaking change.
-- Engineering:
-  - Updated to PSRule v0.20.0. [#34](https://github.com/microsoft/ps-rule/issues/34)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200)
-
-See [upgrade notes][upgrade-v0.3.0] for helpful information when upgrading from previous versions.
-
-[upgrade-v0.3.0]: docs/upgrade-notes.md#upgrade-to-v030-from-v02x
-
-## v0.2.0
-
-What's changed since v0.1.0:
-
-- Engineering:
-  - Updated to PSRule v0.19.0. [#27](https://github.com/microsoft/ps-rule/issues/27)
-    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0190)
-
-## v0.1.0
-
-- Initial release.
+- [v0](docs/CHANGELOG-v0.md)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: Microsoft/ps-rule@v0.5.0
+  uses: Microsoft/ps-rule@v1.0.0
 ```
 
 To get the latest bits use:
@@ -104,7 +104,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@main
 
     - name: Run PSRule analysis
       uses: Microsoft/ps-rule@main

--- a/docs/CHANGELOG-v0.md
+++ b/docs/CHANGELOG-v0.md
@@ -1,0 +1,54 @@
+# Change log
+
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+
+[upgrade-notes]: upgrade-notes.md
+
+## v0.5.0
+
+What's changed since v0.4.0:
+
+- General improvements:
+  - Added support for markdown output format. [#47](https://github.com/microsoft/ps-rule/issues/47)
+- Engineering:
+  - Updated to PSRule v0.22.0. [#45](https://github.com/microsoft/ps-rule/issues/45)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0220)
+
+## v0.4.0
+
+What's changed since v0.3.0:
+
+- Engineering:
+  - Updated to PSRule v0.21.0. [#41](https://github.com/microsoft/ps-rule/issues/41)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0210)
+- Bug fixes:
+  - Updated README example rule to use `PSRule.Data.RepositoryInfo` type filter. [#37](https://github.com/microsoft/ps-rule/issues/37)
+
+## v0.3.0
+
+What's changed since v0.2.0:
+
+- General improvements:
+  - **Breaking change**: Updated `ps-rule` action to use `File` input format for repository analysis. [#33](https://github.com/microsoft/ps-rule/issues/33)
+    - The `Input.PathIgnore` option can be configured to exclude files.
+    - Path specs included in `.gitignore` are also automatically excluded.
+    - See [upgrade notes][upgrade-v0.3.0] for details on breaking change.
+- Engineering:
+  - Updated to PSRule v0.20.0. [#34](https://github.com/microsoft/ps-rule/issues/34)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200)
+
+See [upgrade notes][upgrade-v0.3.0] for helpful information when upgrading from previous versions.
+
+[upgrade-v0.3.0]: upgrade-notes.md#upgrade-to-v030-from-v02x
+
+## v0.2.0
+
+What's changed since v0.1.0:
+
+- Engineering:
+  - Updated to PSRule v0.19.0. [#27](https://github.com/microsoft/ps-rule/issues/27)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0190)
+
+## v0.1.0
+
+- Initial release.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -1,0 +1,14 @@
+# Change log
+
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+
+[upgrade-notes]: upgrade-notes.md
+
+## v1.0.0
+
+What's changed since v0.5.0:
+
+- Engineering:
+  - Updated to PSRule v1.0.0. [#52](https://github.com/microsoft/ps-rule/issues/52)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100)
+  - Updated docker image to PowerShell version v7.1. [#53](https://github.com/microsoft/ps-rule/issues/53)


### PR DESCRIPTION
## PR Summary

What's changed since v0.5.0:

- Engineering:
  - Updated to PSRule v1.0.0. #52
    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v100)
  - Updated docker image to PowerShell version v7.1. #53

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
