### PR TITLE
Release v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: Microsoft/ps-rule@v1.1.0
+  uses: Microsoft/ps-rule@v1.1.1
 ```
 
 To get the latest bits use:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.1.1
+
 What's changed since v1.1.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v1.1.0:

- Engineering:
  - Bump PSRule dependency to v1.0.3. #67
  - Bump PowerShell base image to 7.1.2-alpine-3.12. #68

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
