### PR TITLE
Bump PSRule dependency to v1.2.0 #75 #76

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=1.1.0
+ARG MODULE_VERSION=1.2.0
 
-FROM mcr.microsoft.com/powershell:7.1.2-alpine-3.12-20210211
+FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210316
 SHELL ["pwsh", "-Command"]
 RUN $ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; \
     $Null = New-Item -Path /ps_modules/ -ItemType Directory -Force; \

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.2.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.2.0. [#75](https://github.com/microsoft/ps-rule/issues/75)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v120)
+  - Bump PowerShell base image to 7.1.3-alpine-3.12. [#76](https://github.com/microsoft/ps-rule/issues/76)
+
 ## v1.2.0
 
 What's changed since v1.1.1:

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^1.1.0
+  PSRule: ^1.2.0
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.2.0. #75
- Bump PowerShell base image to 7.1.3-alpine-3.12. #76

Fixes #76 
Fixes #75 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
