### PR TITLE
Release v1.4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 1.3.0]**
+- Version: **[e.g. 1.4.0]**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: Microsoft/ps-rule@v1.3.0
+  uses: Microsoft/ps-rule@v1.4.0
 ```
 
 To get the latest bits use:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.4.0
+
 What's changed since v1.3.0:
 
 - Engineering:

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -7,7 +7,7 @@ This document contains notes to help upgrade from previous versions of the PSRul
 Follow these notes to upgrade from action version _v0.2.x_ to _v0.3.0_.
 For a list of upstream changes to the PSRule engine see [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200).
 
-## Repository analysis
+### Repository analysis
 
 Previously in _v0.2.0_ or prior using `inputType: repository` would:
 


### PR DESCRIPTION
## PR Summary

What's changed since v1.3.0:

- Engineering:
  - Bump PSRule dependency to v1.3.0. #83
    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v130)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
