### PR TITLE
Bump PSRule dependency to v1.5.0 #96

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.5.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.5.0. [#96](https://github.com/microsoft/ps-rule/issues/96)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v150)
+  - Bump PowerShell base image to 7.1.3-alpine-3.12-20210616. [#94](https://github.com/microsoft/ps-rule/pull/94)
+
 ## v1.5.0
 
 What's changed since v1.4.0:


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.5.0.

Fixes #96

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
