### PR TITLE
Added support for conventions #109

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ For a list of changes please see the [change log].
     modules: string                                         # Optional. A comma separated list of modules to use for analysis.
     source: string                                          # Optional. A path containing rules to use for analysis.
     baseline: string                                        # Optional. The name of a PSRule baseline to use.
+    conventions: string                                     # Optional. A comma separated list of conventions to use.
     outputFormat: None, Yaml, Json, NUnit3, Csv, Markdown   # Optional. The format to use when writing results to disk.
     outputPath: string                                      # Optional. The file path to write results to.
     path: string                                            # Optional. The working directory PSRule is run from.
@@ -77,8 +78,19 @@ Use this option to include rules that have not been packaged as a module.
 
 The name of a PSRule baseline to use.
 Baselines can be used from modules or specified in a separate file.
-To use a baseline included in a module use `modules:` with `baseline:`.
-To use a baseline specified in a separate file use `source:` with `baseline:`.
+
+- To use a baseline included in a module use `modules:` with `baseline:`.
+- To use a baseline specified in a separate file use `source:` with `baseline:`.
+
+### `conventions`
+
+A comma separated list of conventions to use.
+Conventions can be used from modules or specified in a separate file.
+
+- To use a convention included in a module use `modules:` with `conventions:`.
+- To use a convention specified in a separate file use `source:` with `conventions:`.
+
+For example: `conventions: Monitor.LogAnalytics.Import`
 
 ### `outputFormat`
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,11 @@ inputs:
     default: ''
     required: false
 
+  conventions:
+    description: 'A comma separated list of conventions to use.'
+    default: ''
+    required: false
+
   outputFormat:
     description: 'The format to use when writing results to disk. When set to None results are not written to disk.'
     default: 'None'

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,11 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+- General improvements:
+  - Added support for conventions. [#109](https://github.com/microsoft/ps-rule/issues/109)
+    - Specify one or more conventions by using `conventions: '<convention1>,<convention2>'`.
+    - Conventions can be included from individual files or modules using `source:` and `modules:`.
+
 ## v1.7.0
 
 What's changed since v1.6.0:

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -34,6 +34,10 @@ param (
     [Parameter(Mandatory = $False)]
     [String]$Baseline = $env:INPUT_BASELINE,
 
+    # The conventions to use
+    [Parameter(Mandatory = $False)]
+    [String]$Conventions = $Env:INPUT_CONVENTIONS,
+
     # The output format
     [Parameter(Mandatory = $False)]
     [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv', 'Markdown')]
@@ -86,6 +90,16 @@ if ([String]::IsNullOrEmpty($Source)) {
 }
 else {
     $Source = Join-Path -Path $Path -ChildPath $Source;
+}
+
+# Set conventions
+if (![String]::IsNullOrEmpty($Conventions)) {
+    $Conventions = @($Conventions.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries) | ForEach-Object {
+        $_.Trim();
+    });
+}
+else {
+    $Conventions = @();
 }
 
 function WriteDebug {
@@ -170,6 +184,7 @@ Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";
 Write-Host "[info] Using Baseline: $Baseline";
+Write-Host "[info] Using Conventions: $Conventions";
 Write-Host "[info] Using InputType: $InputType";
 Write-Host "[info] Using InputPath: $InputPath";
 Write-Host "[info] Using OutputFormat: $OutputFormat";
@@ -187,6 +202,10 @@ try {
     if (![String]::IsNullOrEmpty($Baseline)) {
         $invokeParams['Baseline'] = $Baseline;
         WriteDebug ([String]::Concat('-Baseline ''', $Baseline, ''''));
+    }
+    if ($Conventions.Length -gt 0) {
+        $invokeParams['Convention'] = $Conventions;
+        WriteDebug ([String]::Concat('-Convention ', [String]::Join(', ', $Conventions)));
     }
     if (![String]::IsNullOrEmpty($Modules)) {
         $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);


### PR DESCRIPTION
## PR Summary

- Added support for conventions.
  - Specify one or more conventions by using `conventions: '<convention1>,<convention2>'`.
  - Conventions can be included from individual files or modules using `source:` and `modules:`.

Fixes #109 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
