### PR TITLE
Release v1.8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 1.8.0]**
+- Version: **[e.g. 1.8.1]**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: Microsoft/ps-rule@v1.8.0
+  uses: Microsoft/ps-rule@v1.8.1
 ```
 
 To get the latest bits use:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.8.1
+
 What's changed since v1.8.0:
 
 - Engineering:

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^1.7.0
+  PSRule: ^1.7.2
 
 tasks:
   clear:


### PR DESCRIPTION
## PR Summary

What's changed since v1.8.0:

- Engineering:
  - Bump PSRule dependency to v1.7.2. #114
    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v172)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
