### PR TITLE
Bump PSRule dependency to v1.9.0 #120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=1.8.0
+ARG MODULE_VERSION=1.9.0
 
 FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210803
 SHELL ["pwsh", "-Command"]

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.9.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.9.0. [#120](https://github.com/microsoft/ps-rule/issues/120)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v190)
+
 ## v1.9.0
 
 What's changed since v1.8.1:

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^1.8.0
+  PSRule: ^1.9.0
 
 tasks:
   clear:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -6,7 +6,7 @@
 # https://microsoft.github.io/PSRule/
 
 requires:
-  PSRule: '>=1.8.0'
+  PSRule: '>=1.9.0'
 
 output:
   culture:


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.9.0.

Fixes #120

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [x] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
