### PR TITLE
Update dependencies #125 #126

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-ARG MODULE_VERSION=1.9.0
+ARG MODULE_VERSION=1.10.0
 
-FROM mcr.microsoft.com/powershell:7.1.3-alpine-3.12-20210803
+FROM mcr.microsoft.com/powershell:7.2.1-alpine-3.14-20211215
 SHELL ["pwsh", "-Command"]
 RUN $ProgressPreference = [System.Management.Automation.ActionPreference]::SilentlyContinue; \
     $Null = New-Item -Path /ps_modules/ -ItemType Directory -Force; \

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v1.10.0:
+
+- Engineering:
+  - Bump PSRule dependency to v1.10.0. [#125](https://github.com/microsoft/ps-rule/issues/125)
+    - See the [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v1.md#v1100)
+  - Bump PowerShell base image to 7.2.1-alpine-3.14-20211215. [#126](https://github.com/microsoft/ps-rule/issues/126)
+
 ## v1.10.0
 
 What's changed since v1.9.0:


### PR DESCRIPTION
## PR Summary

- Bump PSRule dependency to v1.10.0. #125
- Bump PowerShell base image to 7.2.1-alpine-3.14-20211215. #126

Fixes #125 
Fixes #126 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
