### PR TITLE
Release v1.11.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 1.10.0]**
+- Version: **[e.g. 1.11.0]**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: Microsoft/ps-rule@v1.10.0
+  uses: Microsoft/ps-rule@v1.11.0
 ```
 
 To get the latest bits use:

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v1.11.0
+
 What's changed since v1.10.0:
 
 - Engineering:

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -130,6 +130,13 @@ else {
     }
 }
 
+# Look for existing modules
+$installed = @(Get-InstalledModule)
+foreach ($m in $installed) {
+    Write-Host "[info] Using existing module $($m.Name): $($m.Version)";
+}
+Write-Host '';
+
 $moduleNames = @()
 if (![String]::IsNullOrEmpty($Modules)) {
     $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);
@@ -170,7 +177,7 @@ foreach ($m in $moduleNames) {
 
 try {
     $Null = Import-Module PSRule -ErrorAction Stop;
-    $version = (Get-InstalledModule PSRule).Version;
+    $version = (Get-Module PSRule).Version;
 }
 catch {
     Write-Host "::error::An error occured importing module 'PSRule'.";
@@ -180,6 +187,7 @@ catch {
 Write-Host '';
 Write-Host "[info] Using Version: $version";
 Write-Host "[info] Using Action: $Env:GITHUB_ACTION";
+Write-Host "[info] Using Workspace: $workspacePath"
 Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";

--- a/ps-project.yaml
+++ b/ps-project.yaml
@@ -14,7 +14,7 @@ bugs:
   url: https://github.com/Microsoft/ps-rule/issues
 
 modules:
-  PSRule: ^1.9.0
+  PSRule: ^1.10.0
 
 tasks:
   clear:

--- a/ps-rule.yaml
+++ b/ps-rule.yaml
@@ -6,7 +6,7 @@
 # https://microsoft.github.io/PSRule/
 
 requires:
-  PSRule: '>=1.9.0'
+  PSRule: '>=1.10.0'
 
 output:
   culture:


### PR DESCRIPTION
## PR Summary

What's changed since v1.10.0:

- Engineering:
  - Bump PSRule dependency to v1.10.0. #125
  - Bump PowerShell base image to 7.2.1-alpine-3.14-20211215. #126

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
