### PR TITLE
Expose rule exception message

### DIFF
--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -20,6 +20,8 @@ What's changed since v1.12.0:
       - Set the `version` parameter to `2.0.0-B2201161` or newer version.
 - Bug fixes:
   - Fixed import of pre-release version. [#138](https://github.com/microsoft/ps-rule/issues/138)
+- General improvements:
+  - Exposed more rule error output in CI. [#140](https://github.com/microsoft/ps-rule/issues/140)
 
 ## v1.12.0
 

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -254,6 +254,10 @@ try {
         Assert-PSRule @invokeParams -InputPath $InputPath;
     }
 }
+catch [PSRule.Pipeline.RuleException] {
+    Write-Host "::error::Rule exception: $($_.Exception.Message)";
+    $Host.SetShouldExit(1);
+}
 catch {
     Write-Host "::error::One or more assertions failed.";
     $Host.SetShouldExit(1);


### PR DESCRIPTION
## PR Summary

Fixes #140.

CI now shows rule exception message:

![Screenshot 2022-02-13 011018](https://user-images.githubusercontent.com/20082136/153736920-c4730bf9-ebc2-4361-bae2-19091bca5561.jpg)

This also doesn't halt the pipeline if a rule like below throws an exception.

**Rule**

```pwsh
Rule 'Org.Throw' {
    throw 'Test Throw'
}
```

**Output**

![Screenshot 2022-02-13 141812](https://user-images.githubusercontent.com/20082136/153736948-06a00101-9e20-4254-a45c-b328ca208a6f.jpg)


## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
