### PR TITLE
Release v2.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 1.12.0]**
+- Version: **[e.g. 2.0.0]**
 
 **Additional context**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 - **Code changes**
   - [ ] Have unit tests created/ updated
   - [ ] Link to a filed issue
-  - [ ] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v1.md) has been updated with change under unreleased section
+  - [ ] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,8 @@
     },
     "[markdown]": {
         "editor.tabSize": 2
-    }
+    },
+    "cSpell.words": [
+        "SARIF"
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Current release
 
-- [v1](docs/CHANGELOG-v1.md)
+- [v2](docs/CHANGELOG-v2.md)
 
 ## Prior releases
 
+- [v1](docs/CHANGELOG-v1.md)
 - [v0](docs/CHANGELOG-v0.md)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v1.12.0
+  uses: microsoft/ps-rule@v2.0.0
 ```
 
 To get the latest bits use:
@@ -22,6 +22,16 @@ To get the latest bits use:
 ```yaml
 - name: Run PSRule analysis
   uses: microsoft/ps-rule@main
+```
+
+To use the latest action with an older version of PSRule, you can use the `version` parameter.
+For example:
+
+```yaml
+- name: Run PSRule analysis
+  uses: microsoft/ps-rule@v2.0.0
+  with:
+    version: '1.11.1'
 ```
 
 For a list of changes please see the [change log][2].
@@ -157,7 +167,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v1.12.0`.
+2. Reference `microsoft/ps-rule@v2.0.0`.
 For example:
 
 ```yaml
@@ -170,10 +180,10 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v1.12.0
+      uses: microsoft/ps-rule@v2.0.0
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v1.md
+++ b/docs/CHANGELOG-v1.md
@@ -4,28 +4,6 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 [upgrade-notes]: upgrade-notes.md
 
-## Unreleased
-
-What's changed since v1.12.0:
-
-- New features:
-  - Added support for using a specific version of PSRule. [#132](https://github.com/microsoft/ps-rule/issues/132)
-    - To install a specific version set the `version` parameter.
-    - By default, the latest stable version of PSRule is used.
-  - Added support for outputting analysis results as SARIF. [#136](https://github.com/microsoft/ps-rule/issues/136)
-    - To use the SARIF output format set the `outputFormat` parameter to `Sarif`.
-  - Added the ability to use an alternative PowerShell repository. [#133](https://github.com/microsoft/ps-rule/issues/133)
-    - Register and authenticate to the repository in PowerShell if required.
-    - Configure `repository` to install modules from the named repository.
-- General improvements:
-  - Exposed more rule error output in CI. [#140](https://github.com/microsoft/ps-rule/issues/140)
-- Engineering:
-  - Bump PSRule dependency to v2.0.0. [#152](https://github.com/microsoft/ps-rule/pull/152)
-    - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v200)
-- Bug fixes:
-  - Fixed import of pre-release version. [#138](https://github.com/microsoft/ps-rule/issues/138)
-  - Fixed path issue for running out of repo. [#150](https://github.com/microsoft/ps-rule/issues/150)
-
 ## v1.12.0
 
 What's changed since v1.11.0:

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -1,0 +1,29 @@
+# Change log
+
+See [upgrade notes][upgrade-notes] for helpful information when upgrading from previous versions.
+
+[upgrade-notes]: upgrade-notes.md
+
+## Unreleased
+
+## v2.0.0
+
+What's changed since v1.12.0:
+
+- New features:
+  - Added support for using a specific version of PSRule. [#132](https://github.com/microsoft/ps-rule/issues/132)
+    - To install a specific version set the `version` parameter.
+    - By default, the latest stable version of PSRule is used.
+  - Added support for outputting analysis results as SARIF. [#136](https://github.com/microsoft/ps-rule/issues/136)
+    - To use the SARIF output format set the `outputFormat` parameter to `Sarif`.
+  - Added the ability to use an alternative PowerShell repository. [#133](https://github.com/microsoft/ps-rule/issues/133)
+    - Register and authenticate to the repository in PowerShell if required.
+    - Configure `repository` to install modules from the named repository.
+- General improvements:
+  - Exposed more rule error output in CI. [#140](https://github.com/microsoft/ps-rule/issues/140)
+- Engineering:
+  - **Breaking change:** Bump PSRule dependency to v2.0.0. [#152](https://github.com/microsoft/ps-rule/pull/152)
+    - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v200)
+- Bug fixes:
+  - Fixed import of pre-release version. [#138](https://github.com/microsoft/ps-rule/issues/138)
+  - Fixed path issue for running out of repo. [#150](https://github.com/microsoft/ps-rule/issues/150)

--- a/docs/upgrade-notes.md
+++ b/docs/upgrade-notes.md
@@ -2,10 +2,45 @@
 
 This document contains notes to help upgrade from previous versions of the PSRule GitHub Action.
 
+## Upgrade to v2.0.0 from v1.12.0
+
+This release of the PSRule GitHub Action moves to PSRule v2.
+PSRule v2 introduces a number of breaking changes.
+Please review the [upgrade notes](https://microsoft.github.io/PSRule/v2/upgrade-notes/#upgrading-to-v200) for details.
+
+To continue to use PSRule v1, please target the `v1.12.0` release.
+For example:
+
+```yaml
+- name: Run PSRule analysis
+  uses: microsoft/ps-rule@v1.12.0
+```
+
+**Note:** Some rules modules may depend on PSRule v2.
+To continue to work with PSRule v1 you may need to install older versions of these modules via PowerShell.
+
+To use the latest action with an older version of PSRule, you can use the `version` parameter.
+For example:
+
+```yaml
+- name: Run PSRule analysis
+  uses: microsoft/ps-rule@v2.0.0
+  with:
+    version: '1.11.1'
+```
+
+To upgrade to PSRule v2, target the `v2.0.0` release.
+For example:
+
+```yaml
+- name: Run PSRule analysis
+  uses: microsoft/ps-rule@v2.0.0
+```
+
 ## Upgrade to v0.3.0 from v0.2.x
 
 Follow these notes to upgrade from action version _v0.2.x_ to _v0.3.0_.
-For a list of upstream changes to the PSRule engine see [change log](https://github.com/microsoft/PSRule/blob/main/docs/CHANGELOG-v0.md#v0200).
+For a list of upstream changes to the PSRule engine see [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v0/#v0200).
 
 ### Repository analysis
 
@@ -86,4 +121,4 @@ Rule 'OpenSource.License' -Type '.cs', '.ps1', '.psd1', '.psm1' {
 
 > To read more about the new `FilePath` and `FileHeader` assertion helpers see [about_PSRule_Assert]
 
-[about_PSRule_Assert]: https://microsoft.github.io/PSRule/concepts/PSRule/en-US/about_PSRule_Assert.html
+[about_PSRule_Assert]: https://microsoft.github.io/PSRule/v2/commands/PSRule/en-US/Assert-PSRule/


### PR DESCRIPTION
## PR Summary

What's changed since v1.12.0:

- New features:
  - Added support for using a specific version of PSRule. #132
    - To install a specific version set the `version` parameter.
    - By default, the latest stable version of PSRule is used.
  - Added support for outputting analysis results as SARIF. #136
    - To use the SARIF output format set the `outputFormat` parameter to `Sarif`.
  - Added the ability to use an alternative PowerShell repository. #133
    - Register and authenticate to the repository in PowerShell if required.
    - Configure `repository` to install modules from the named repository.
- General improvements:
  - Exposed more rule error output in CI. #140
- Engineering:
  - **Breaking change:** Bump PSRule dependency to v2.0.0. #152
    - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v200)
- Bug fixes:
  - Fixed import of pre-release version. #138
  - Fixed path issue for running out of repo. #150

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
