### PR TITLE
Add support for alternative option file #155

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ For a list of changes please see the [change log][2].
     source: string                                               # Optional. A path containing rules to use for analysis.
     baseline: string                                             # Optional. The name of a PSRule baseline to use.
     conventions: string                                          # Optional. A comma separated list of conventions to use.
+    option: string                                               # Optional. The path to an options file.
     outputFormat: None, Yaml, Json, NUnit3, Csv, Markdown, Sarif # Optional. The format to use when writing results to disk.
     outputPath: string                                           # Optional. The file path to write results to.
     path: string                                                 # Optional. The working directory PSRule is run from.
@@ -109,6 +110,12 @@ Conventions can be used from modules or specified in a separate file.
 - To use a convention specified in a separate file use `source:` with `conventions:`.
 
 For example: `conventions: Monitor.LogAnalytics.Import`
+
+### `option`
+
+The path to an options file.
+By default, `ps-rule.yaml` will be used if it exists.
+Configure this parameter to use a different file.
 
 ### `outputFormat`
 

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,11 @@ inputs:
     default: ''
     required: false
 
+  option:
+    description: 'The path to an options file.'
+    default: ''
+    required: false
+
   outputFormat:
     description: 'The format to use when writing results to disk. When set to None results are not written to disk.'
     default: 'None'
@@ -76,4 +81,4 @@ runs:
     shell: pwsh
     working-directory: ${{ github.workspace }}
     run: |-
-      ${{ github.action_path }}/powershell.ps1 -InputType '${{ inputs.inputType }}' -InputPath '${{ inputs.inputPath }}' -Modules '${{ inputs.modules }}' -Source '${{ inputs.source }}' -Baseline '${{ inputs.baseline }}' -Conventions '${{ inputs.conventions }}' -OutputFormat '${{ inputs.outputFormat }}' -OutputPath '${{ inputs.outputPath }}' -Path '${{ inputs.path }}' -PreRelease '${{ inputs.prerelease }}' -Repository '${{ inputs.repository }}' -Version '${{ inputs.version }}'
+      ${{ github.action_path }}/powershell.ps1 -InputType '${{ inputs.inputType }}' -InputPath '${{ inputs.inputPath }}' -Modules '${{ inputs.modules }}' -Source '${{ inputs.source }}' -Baseline '${{ inputs.baseline }}' -Conventions '${{ inputs.conventions }}' -Option '${{ inputs.option }}' -OutputFormat '${{ inputs.outputFormat }}' -OutputPath '${{ inputs.outputPath }}' -Path '${{ inputs.path }}' -PreRelease '${{ inputs.prerelease }}' -Repository '${{ inputs.repository }}' -Version '${{ inputs.version }}'

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,13 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v2.0.0:
+
+- New features:
+  - Added support for alternative option file. [#155](https://github.com/microsoft/ps-rule/issues/155)
+    - Set the `option` parameter to the path to an options file.
+    - By default, the `ps-rule.yaml` option file is used.
+
 ## v2.0.0
 
 What's changed since v1.12.0:

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -38,6 +38,10 @@ param (
     [Parameter(Mandatory = $False)]
     [String]$Conventions = $Env:INPUT_CONVENTIONS,
 
+    # The path to an options file.
+    [Parameter(Mandatory = $False)]
+    [String]$Option = $Env:INPUT_OPTION,
+
     # The output format
     [Parameter(Mandatory = $False)]
     [ValidateSet('None', 'Yaml', 'Json', 'NUnit3', 'Csv', 'Markdown', 'Sarif')]
@@ -209,7 +213,7 @@ catch {
 Write-Host '';
 Write-Host "[info] Using Version: $version";
 Write-Host "[info] Using Action: $Env:GITHUB_ACTION";
-Write-Host "[info] Using Workspace: $workspacePath"
+Write-Host "[info] Using Workspace: $workspacePath";
 Write-Host "[info] Using PWD: $PWD";
 Write-Host "[info] Using Path: $Path";
 Write-Host "[info] Using Source: $Source";
@@ -217,6 +221,7 @@ Write-Host "[info] Using Baseline: $Baseline";
 Write-Host "[info] Using Conventions: $Conventions";
 Write-Host "[info] Using InputType: $InputType";
 Write-Host "[info] Using InputPath: $InputPath";
+Write-Host "[info] Using Option: $Option";
 Write-Host "[info] Using OutputFormat: $OutputFormat";
 Write-Host "[info] Using OutputPath: $OutputPath";
 
@@ -241,6 +246,10 @@ try {
         $moduleNames = $Modules.Split(',', [System.StringSplitOptions]::RemoveEmptyEntries);
         $invokeParams['Module'] = $moduleNames;
         WriteDebug ([String]::Concat('-Module ', [String]::Join(', ', $moduleNames)));
+    }
+    if (![String]::IsNullOrEmpty($Option)) {
+        $invokeParams['Option'] = $Option;
+        WriteDebug ([String]::Concat('-Option ', $Option));
     }
     if (![String]::IsNullOrEmpty($OutputFormat) -and ![String]::IsNullOrEmpty($OutputPath) -and $OutputFormat -ne 'None') {
         $invokeParams['OutputFormat'] = $OutputFormat;


### PR DESCRIPTION
## PR Summary

- Added support for alternative option file.
  - Set the `option` parameter to the path to an options file.
  - By default, the `ps-rule.yaml` option file is used.

Fixes #155 

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
- **Code changes**
  - [ ] Have unit tests created/ updated
  - [x] Link to a filed issue
  - [x] [Change log](https://github.com/Microsoft/ps-rule/blob/main/docs/CHANGELOG-v2.md) has been updated with change under unreleased section
