### PR TITLE
Merge fixes for v2.0.1 from main

### DIFF
--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -30,7 +30,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: Microsoft/ps-rule@v1.12.0
+      uses: microsoft/ps-rule@main
       with:
         modules: PSRule.Rules.MSFT.OSS
         prerelease: true

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+What's changed since v2.0.0:
+
+- Engineering:
+  - Bump PSRule dependency to v2.0.1. [#158](https://github.com/microsoft/ps-rule/pull/158)
+    - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v201)
+
 ## v2.0.0
 
 What's changed since v1.12.0:

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -11,6 +11,8 @@ What's changed since v2.0.0:
 - Engineering:
   - Bump PSRule dependency to v2.0.1. [#158](https://github.com/microsoft/ps-rule/pull/158)
     - See the [change log](https://microsoft.github.io/PSRule/latest/CHANGELOG-v2/#v201)
+- Bug fixes:
+  - Fixed assertion failed with newer version. [#159](https://github.com/microsoft/ps-rule/issues/159)
 
 ## v2.0.0
 

--- a/modules.json
+++ b/modules.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "PSRule": {
-      "version": "2.0.0"
+      "version": "2.0.1"
     }
   },
   "devDependencies": {}

--- a/powershell.ps1
+++ b/powershell.ps1
@@ -194,7 +194,7 @@ foreach ($m in $moduleNames) {
 }
 
 try {
-    $checkParams = @{ RequiredVersion = $checkParams.RequiredVersion.Split('-')[0] }
+    $checkParams = @{ MinimumVersion = $checkParams.RequiredVersion.Split('-')[0] }
     $Null = Import-Module PSRule @checkParams -ErrorAction Stop;
     $version = (Get-Module PSRule).Version;
 }


### PR DESCRIPTION
## PR Summary

Merge fixes from main for upcoming patch release v2.0.1.

- Engineering:
  - Bump PSRule dependency to v2.0.1. #158
- Bug fixes:
  - Fixed assertion failed with newer version. #159

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
