### PR TITLE
Release v2.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 2.1.0]**
+- Version: **[e.g. 2.2.0]**
 
 **Additional context**
 

--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -3,7 +3,7 @@
 #
 
 # NOTES:
-# This worflow uses PSRule, and DevSkim.
+# This workflow uses PSRule, and DevSkim.
 # You can read more about these linting tools and configuration options here:
 #   PSRule - https://aka.ms/ps-rule and https://github.com/Microsoft/PSRule.Rules.MSFT.OSS
 #   DevSkim - https://github.com/microsoft/DevSkim-Action and https://github.com/Microsoft/DevSkim

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PSRule
 
 Validate infrastructure as code (IaC) and DevOps repositories using rules.
-PSRule allows you to analyse a repository with pre-built rules or create your own.
+PSRule allows you to analyze a repository with pre-built rules or create your own.
 Analysis can be performed from input files or the repository structure.
 
 To learn about PSRule and how to write your own rules see [Getting started][1].
@@ -14,7 +14,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.1.0
+  uses: microsoft/ps-rule@v2.2.0
 ```
 
 To get the latest bits use:
@@ -29,7 +29,7 @@ For example:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.1.0
+  uses: microsoft/ps-rule@v2.2.0
   with:
     version: '1.11.1'
 ```
@@ -174,7 +174,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v2.1.0`.
+2. Reference `microsoft/ps-rule@v2.2.0`.
 For example:
 
 ```yaml
@@ -190,7 +190,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.1.0
+      uses: microsoft/ps-rule@v2.2.0
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v2.2.0
+
 What's changed since v2.1.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.1.0:

- Engineering:
  - Bump PSRule dependency to v2.2.0. [#168](https://github.com/microsoft/ps-rule/pull/168)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v220)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
