### PR TITLE
Release v2.3.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 2.2.0]**
+- Version: **[e.g. 2.3.0]**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.2.0
+  uses: microsoft/ps-rule@v2.3.0
 ```
 
 To get the latest bits use:
@@ -29,7 +29,7 @@ For example:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.2.0
+  uses: microsoft/ps-rule@v2.3.0
   with:
     version: '1.11.1'
 ```
@@ -174,7 +174,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v2.2.0`.
+2. Reference `microsoft/ps-rule@v2.3.0`.
 For example:
 
 ```yaml
@@ -190,7 +190,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.2.0
+      uses: microsoft/ps-rule@v2.3.0
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,10 +6,12 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v2.3.0
+
 What's changed since v2.2.0:
 
 - Engineering:
-  - Bump PSRule dependency to v2.2.0. [#172](https://github.com/microsoft/ps-rule/pull/172)
+  - Bump PSRule to v2.3.0. [#172](https://github.com/microsoft/ps-rule/pull/172)
     - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v230)
 
 ## v2.2.0
@@ -17,7 +19,7 @@ What's changed since v2.2.0:
 What's changed since v2.1.0:
 
 - Engineering:
-  - Bump PSRule dependency to v2.2.0. [#168](https://github.com/microsoft/ps-rule/pull/168)
+  - Bump PSRule to v2.2.0. [#168](https://github.com/microsoft/ps-rule/pull/168)
     - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v220)
 
 ## v2.1.0
@@ -29,7 +31,7 @@ What's changed since v2.0.1:
     - Set the `option` parameter to the path to an options file.
     - By default, the `ps-rule.yaml` option file is used.
 - Engineering:
-  - Bump PSRule dependency to v2.1.0. [#165](https://github.com/microsoft/ps-rule/pull/165)
+  - Bump PSRule to v2.1.0. [#165](https://github.com/microsoft/ps-rule/pull/165)
     - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v210)
 
 ## v2.0.1
@@ -37,7 +39,7 @@ What's changed since v2.0.1:
 What's changed since v2.0.0:
 
 - Engineering:
-  - Bump PSRule dependency to v2.0.1. [#158](https://github.com/microsoft/ps-rule/pull/158)
+  - Bump PSRule to v2.0.1. [#158](https://github.com/microsoft/ps-rule/pull/158)
     - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v201)
 - Bug fixes:
   - Fixed assertion failed with newer version. [#159](https://github.com/microsoft/ps-rule/issues/159)
@@ -58,7 +60,7 @@ What's changed since v1.12.0:
 - General improvements:
   - Exposed more rule error output in CI. [#140](https://github.com/microsoft/ps-rule/issues/140)
 - Engineering:
-  - **Breaking change:** Bump PSRule dependency to v2.0.0. [#152](https://github.com/microsoft/ps-rule/pull/152)
+  - **Breaking change:** Bump PSRule to v2.0.0. [#152](https://github.com/microsoft/ps-rule/pull/152)
     - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v200)
 - Bug fixes:
   - Fixed import of pre-release version. [#138](https://github.com/microsoft/ps-rule/issues/138)


### PR DESCRIPTION
## PR Summary

What's changed since v2.2.0:

- Engineering:
  - Bump PSRule to v2.3.0. [#172](https://github.com/microsoft/ps-rule/pull/172)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v230)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
