### PR TITLE
Release v2.4.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **[e.g. 2.4.0]**
+- Version: **microsoft/ps-rule@v2.4.1**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.4.0
+  uses: microsoft/ps-rule@v2.4.1
 ```
 
 To get the latest bits use:
@@ -29,7 +29,7 @@ For example:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.4.0
+  uses: microsoft/ps-rule@v2.4.1
   with:
     version: '1.11.1'
 ```
@@ -179,7 +179,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v2.4.0`.
+2. Reference `microsoft/ps-rule@v2.4.1`.
 For example:
 
 ```yaml
@@ -195,7 +195,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.4.0
+      uses: microsoft/ps-rule@v2.4.1
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v2.4.1
+
 What's changed since v2.4.0:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.4.0:

- Engineering:
  - Bump PSRule to v2.4.1.
    [#188](https://github.com/microsoft/ps-rule/pull/188)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v241)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
