### PR TITLE
Release v2.5.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **microsoft/ps-rule@v2.5.1**
+- Version: **microsoft/ps-rule@v2.5.2**
 
 **Additional context**
 

--- a/.github/workflows/analyze.yaml
+++ b/.github/workflows/analyze.yaml
@@ -11,11 +11,11 @@
 name: Analyze
 on:
   push:
-    branches: [ main, 'release/*', 'dependencies/*' ]
+    branches: [main, 'release/*', 'dependencies/*']
   pull_request:
-    branches: [ main, 'release/*' ]
+    branches: [main, 'release/*']
   schedule:
-  - cron: '42 18 * * 0' # At 6:42 PM, on Sunday each week
+    - cron: '42 18 * * 0' # At 6:42 PM, on Sunday each week
   workflow_dispatch:
 
 jobs:
@@ -25,15 +25,14 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.5.1
-      with:
-        modules: PSRule.Rules.MSFT.OSS
-        prerelease: true
+      - name: Run PSRule analysis
+        uses: microsoft/ps-rule@v2.5.2
+        with:
+          modules: PSRule.Rules.MSFT.OSS
+          prerelease: true
 
   devskim:
     name: Analyze with DevSkim
@@ -43,7 +42,6 @@ jobs:
       contents: read
       security-events: write
     steps:
-
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To get the latest stable release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.5.1
+  uses: microsoft/ps-rule@v2.5.2
 ```
 
 To get the latest bits use:
@@ -29,7 +29,7 @@ For example:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.5.1
+  uses: microsoft/ps-rule@v2.5.2
   with:
     version: '1.11.1'
 ```
@@ -186,7 +186,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/en/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v2.5.1`.
+2. Reference `microsoft/ps-rule@v2.5.2`.
 For example:
 
 ```yaml
@@ -202,7 +202,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.5.1
+      uses: microsoft/ps-rule@v2.5.2
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,8 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v2.5.2
+
 What's changed since v2.5.1:
 
 - Engineering:


### PR DESCRIPTION
## PR Summary

What's changed since v2.5.1:

- Engineering:
  - Bump PSRule to v2.5.3.
    [#203](https://github.com/microsoft/ps-rule/pull/203)
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v253)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
