### PR TITLE
Release v2.8.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ Steps to reproduce the issue:
 
 **Action version:**
 
-- Version: **microsoft/ps-rule@v2.8.0**
+- Version: **microsoft/ps-rule@v2.8.1**
 
 **Additional context**
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To get a specific release use:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.8.0
+  uses: microsoft/ps-rule@v2.8.1
 ```
 
 To get the latest bits use:
@@ -43,7 +43,7 @@ For example:
 
 ```yaml
 - name: Run PSRule analysis
-  uses: microsoft/ps-rule@v2.8.0
+  uses: microsoft/ps-rule@v2.8.1
   with:
     version: '1.11.1'
 ```
@@ -207,7 +207,7 @@ When set:
 To use PSRule:
 
 1. See [Creating a workflow file](https://help.github.com/articles/configuring-a-workflow#creating-a-workflow-file).
-2. Reference `microsoft/ps-rule@v2.8.0`.
+2. Reference `microsoft/ps-rule@v2.8.1`.
 For example:
 
 ```yaml
@@ -223,7 +223,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Run PSRule analysis
-      uses: microsoft/ps-rule@v2.8.0
+      uses: microsoft/ps-rule@v2.8.1
 ```
 
 3. Create rules within the `.ps-rule/` directory.

--- a/docs/CHANGELOG-v2.md
+++ b/docs/CHANGELOG-v2.md
@@ -6,6 +6,14 @@ See [upgrade notes][upgrade-notes] for helpful information when upgrading from p
 
 ## Unreleased
 
+## v2.8.1
+
+What's changed since v2.8.1:
+
+- Engineering:
+  - Bump PSRule to v2.8.1.
+    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v281)
+
 ## v2.8.0
 
 What's changed since v2.7.0:

--- a/modules.json
+++ b/modules.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "PSRule": {
-      "version": "2.8.0"
+      "version": "2.8.1"
     }
   },
   "devDependencies": {}


### PR DESCRIPTION
## PR Summary

- Engineering:
  - Bump PSRule to v2.8.1.
    - See the [change log](https://microsoft.github.io/PSRule/v2/CHANGELOG-v2/#v281)

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Change is not breaking
- [x] This PR is ready to merge and is not **Work in Progress**
