### PR TITLE
Pin the dependencies and quality and security.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,11 @@
 name: Build
 on:
   push:
-    branches: [main, 'release/*', 'dependencies/*']
+    branches: [main, "release/*", "dependencies/*"]
   pull_request:
-    branches: [main, 'release/*']
+    branches: [main, "release/*"]
   schedule:
-    - cron: '42 18 * * 0' # At 6:42 PM, on Sunday each week
+    - cron: "42 18 * * 0" # At 6:42 PM, on Sunday each week
   workflow_dispatch:
 
 permissions: {}
@@ -28,7 +28,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Register repository
         shell: pwsh
@@ -46,7 +46,7 @@ jobs:
           inputType: repository
           modules: PSRule.Rules.MSFT.OSS
           repository: Local
-          version: '1.11.1'
+          version: "1.11.1"
 
       - name: Run PSRule v2
         uses: ./
@@ -64,12 +64,12 @@ jobs:
   run:
     name: Analyze repository
     runs-on: ubuntu-latest
-    needs: 'test'
+    needs: "test"
     permissions:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run PSRule self analysis
         uses: ./
@@ -81,7 +81,7 @@ jobs:
           prerelease: true
 
       - name: PSRule results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         if: always()
         with:
           name: PSRule-results
@@ -94,7 +94,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run PSRule analysis
         uses: microsoft/ps-rule@main
@@ -111,10 +111,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run DevSkim scanner
-        uses: microsoft/DevSkim-Action@v1
+        uses: microsoft/DevSkim-Action@a6b6966a33b497cd3ae2ebc406edf8f4cc2feec6 # v1.0.15
         with:
           directory-to-scan: .
 

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -8,7 +8,7 @@
 name: Dependencies
 on:
   schedule:
-    - cron: '50 1 * * 1' # At 01:50 AM, on Monday each week
+    - cron: "50 1 * * 1" # At 01:50 AM, on Monday each week
   workflow_dispatch:
 
 permissions: {}
@@ -26,7 +26,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,9 @@ on:
         description: Determines the release branch to bump.
         required: true
         options:
-          - 'v1'
-          - 'v2'
-          - 'v3'
+          - "v1"
+          - "v2"
+          - "v3"
         default: v3
 
 permissions: {}
@@ -39,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,10 +7,10 @@
 # Issues with open ended labels are automatically closed if no activity occurs.
 # Issues are marked stale after 14 days, then closed after a further 7 days.
 
-name: 'Close stale issues'
+name: "Close stale issues"
 on:
   schedule:
-    - cron: '30 1 * * *' # At 1:30 AM, daily
+    - cron: "30 1 * * *" # At 1:30 AM, daily
 
 permissions: {}
 
@@ -21,14 +21,15 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
+
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs within 7 days.
             Thank you for your contributions.
 
-          close-issue-message: 'This issue was closed because it has not had any recent activity.'
+          close-issue-message: "This issue was closed because it has not had any recent activity."
 
           days-before-stale: 14
           days-before-pr-stale: -1
@@ -36,5 +37,5 @@ jobs:
           days-before-close: 7
           days-before-pr-close: -1
 
-          any-of-labels: 'question,duplicate,incomplete,waiting-feedback'
+          any-of-labels: "question,duplicate,incomplete,waiting-feedback"
           stale-issue-label: stale


### PR DESCRIPTION
Pinning dependencies in a PR description is important for several reasons, particularly when using GitHub Actions or other external dependencies. Here’s why:  

### **1. Security & Integrity** 

Pinning dependencies to a commit SHA ensures that your workflow always runs the exact same version of an action. If an action is referenced by a tag (e.g., `@v9`), the maintainers can update that tag to point to a different commit, potentially introducing breaking changes or security vulnerabilities.  

### **2. Stability & Consistency** 

Pinning to a SHA prevents unexpected behavior due to updates. If an action is updated and introduces a bug, it could break your workflow. Using a pinned SHA guarantees your workflow remains stable until you intentionally update it.  

### **3. Auditing & Compliance** 

Some security and compliance policies require projects to use immutable references for dependencies. Pinning SHAs ensures that the same verified code is always executed, making audits and security reviews easier.  


Thanks